### PR TITLE
Ratelimiter patch

### DIFF
--- a/eom/governor.py
+++ b/eom/governor.py
@@ -238,9 +238,6 @@ def wrap(app, redis_client):
                         'project {project_id} according to '
                         'rate rule "{name}"')
 
-            # time.sleep(throttle_milliseconds)
-            # time.sleep(2)
-
             LOG.warn(message.format(rate=rate.limit,
                                     project_id=project_id,
                                     name=rate.name))

--- a/eom/governor.py
+++ b/eom/governor.py
@@ -134,35 +134,50 @@ def _create_limiter(redis_client):
 
     def calc_sleep(project_id, rate):
         count = 0.0
-        now = time.time()
- 
+
         try:
-            count, last_time = [key for key in
-                                redis_client.hmget(project_id, 'c', 't')]
- 
-            if not all([count, last_time]):
+            now_sec, now_usec = redis_client.execute_command("TIME")
+
+            count, last_time_sec, last_time_usec = [key for key in
+                                                    redis_client.hmget(project_id, 'c', 't_s', 't_us')]
+
+            if not all([count, last_time_sec, last_time_usec]):
                 raise KeyError
- 
-            count, last_time = float(count), float(last_time)
- 
-            # if one second has passed since last reset, reset the count and time.
-            if now - last_time > 1:
-                redis_client.hmset(project_id, {'c': 0.0, 't': now})
- 
+
+            count, last_time_sec, last_time_usec = float(
+                count), float(last_time_sec), float(last_time_usec)
+
+            # if one second has passed since last reset, reset the count and
+            # time.
+            if now_sec - last_time_sec > 1:
+                redis_client.hmset(
+                    project_id, {
+                        'c': 0.0, 't_s': now_sec, 't_us': now_usec})
+
+            elif (now_sec - last_time_sec == 1) and (now_usec > last_time_usec):
+                redis_client.hmset(
+                    project_id, {
+                        'c': 0.0, 't_s': now_sec, 't_us': now_usec})
+
             else:
                 if count + 1 >= rate.limit:
                     raise HardLimitError()
                 else:
-                    # just update the count, keep the counting-start time intact
-                    redis_client.hmset(project_id, {'c': count + 1, 't': last_time})
- 
+                    # just update the count, keep the counting-start time
+                    # intact
+                    redis_client.hmset(
+                        project_id, {
+                            'c': count + 1, 't_s': last_time_sec, 't_us': last_time_usec})
+
         except KeyError:
-            redis_client.hmset(project_id, {'c': 0.0, 't': now})
- 
+            redis_client.hmset(
+                project_id, {
+                    'c': 0.0, 't_s': now_sec, 't_us': now_usec})
+
         except redis.exceptions.ConnectionError as ex:
             message = _('Redis Error:{exception} for Project-ID:{project_id}')
             LOG.warn((message.format(exception=ex, project_id=project_id)))
- 
+
     return calc_sleep
 
 

--- a/tests/functional/test_uwsgi_requests.py
+++ b/tests/functional/test_uwsgi_requests.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2013 Rackspace, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR ONDITIONS OF ANY KIND, either express or
+# implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import time
+import json
+import copy
+import requests
+from multiprocessing import Process, Queue
+from testtools import testcase
+from tests import util
+
+APP_CONTENTS = '''
+from eom.utils import redis_pool
+from eom import governor
+from marconi.queues.transport.wsgi import app as marconi
+
+redis_client = redis_pool.get_client()
+marconi_app = marconi.app
+application = governor.wrap(marconi_app, redis_client)
+'''
+
+
+def _kill_uwsgi_process(process):
+    try:
+        # NOTE(cabrera): using process.terminate instead of
+        # process.kill here because on some platforms, uwsgi will
+        # outright ignore SIGKILL. This was happening on Mac OS
+        # X. Also ensure that the --die-on-term flag in enabled below
+        # in setUp().
+        process.terminate()
+    except OSError:
+        pass
+
+
+class TestUwsgiRequests(util.TestCase):
+
+    def setUp(self):
+        super(TestUwsgiRequests, self).setUp()
+
+        self.limits = {
+            'defaultLimit': 0,
+            'specialLimit': 0,
+            '281928defaultLimit': 0,
+            '281929specialLimit': 0}
+
+        self.getLimits()
+
+        self.appfilename = 'guvapp.py'
+        with open('guvapp.py', 'w') as guvwriter:
+            guvwriter.write(APP_CONTENTS)
+
+        self.port = ':8000'
+        self.socketurl = 'http://127.0.0.1:8000'
+
+        with open(os.devnull, 'wb') as pipeDown:
+            self.uwsgi_process = subprocess.Popen(
+                [
+                    'uwsgi',
+                    '--http-socket', self.port,
+                    '-H',  os.environ.get('VIRTUAL_ENV'),
+                    '--wsgi-file', self.appfilename
+                ], stdout=pipeDown, stderr=pipeDown
+            )
+
+        self.defaultHeaders = {
+            'content-type': 'application/json',
+            'Client-ID': '0fc2b683-e762-475b-855f-9d813daf15a2',
+            'X-Project-ID': '123456'}
+
+        time.sleep(0.5)
+
+    def _get_uwsgi_response(self):
+        _kill_uwsgi_process(self.uwsgi_process)
+
+        # Blocks until the process exits, so no need to sleep
+        _, err = self.uwsgi_process.communicate()
+        return err
+
+    def tearDown(self):
+        _kill_uwsgi_process(self.uwsgi_process)  # Just in case
+        time.sleep(0.3)
+        super(TestUwsgiRequests, self).tearDown()
+
+    def getLimits(self):
+        configPath = os.environ.get('HOME') + '/.marconi/governor.json-sample'
+        with open(configPath, 'r') as configReader:
+            conf = configReader.read()
+            jsnConf = json.loads(conf)
+            self.limits['defaultLimit'] = jsnConf[1]['limit']
+            self.limits['specialLimit'] = jsnConf[0]['limit']
+
+        configPath = '%s/.marconi/governor-project.json-sample' % (
+            os.environ.get('HOME'))
+        with open(configPath, 'r') as configReader:
+            conf = configReader.read()
+            jsnConf = json.loads(conf)
+            self.limits['281928defaultLimit'] = jsnConf[0]['limit']
+            self.limits['281929specialLimit'] = jsnConf[1]['limit']
+
+    def test_GetTillJustOverLimit(self):
+        time.sleep(1)
+        call = lambda: requests.get(
+            self.socketurl + '/v1/queues', headers=self.defaultHeaders)
+        resps = [call().status_code for _ in range(
+            self.limits['defaultLimit'] + 1)]
+        self.assertNotEqual(resps[-2], 429)
+        self.assertEqual(resps[-1], 429)
+
+    def test_LimitResetsAfterWait(self):
+        time.sleep(1)
+        startTime = time.time()
+        call = lambda: requests.get(
+            self.socketurl + '/v1/queues', headers=self.defaultHeaders)
+        resps = [call().status_code for _ in range(
+            self.limits['defaultLimit'] + 1)]
+        endTime = time.time()
+
+        self.assertNotEqual(resps[-2], 429)
+        self.assertEqual(resps[-1], 429)
+        # time.sleep(1 - endTime + startTime + 0.05)
+        self.assertNotEqual(call().status_code, 429)
+
+    def test_PostAndGetLargeMessages(self):
+        # create queue if it doesn't exist
+        time.sleep(1)
+        urlRequest = self.socketurl + '/v1/queues/trillian'
+        reqCheckQueue = requests.get(urlRequest, headers=self.defaultHeaders)
+
+        if reqCheckQueue.status_code != 204:
+            queueData = {'metadata': 'A packetful of metadata'}
+
+            reqAddQueue = requests.put(
+                urlRequest, data=json.dumps(queueData),
+                headers=self.defaultHeaders)
+
+            self.assertEqual(reqAddQueue.status_code, 201)
+
+        # post message
+        time.sleep(1)
+        messageSize = 131080
+        for _ in range(self.limits['defaultLimit'] - 1):
+            rnd = 'o' * messageSize
+            largeData = [{'ttl': 120, 'body': rnd}]
+
+            reqPostMsg = requests.post('%s/v1/queues/trillian/messages' %
+                                       (self.socketurl),
+                                       data=json.dumps(largeData),
+                                       headers=self.defaultHeaders)
+
+            self.assertEqual(reqPostMsg.status_code, 201)
+
+        # get the messages
+        echoParams = {'echo': 'true'}
+        reqGetMsgs = requests.get(
+            self.socketurl + '/v1/queues/trillian/messages/',
+            params=echoParams, headers=self.defaultHeaders)
+        self.assertEqual(reqGetMsgs.status_code, 200)
+
+    def test_BombardAcrossProjectIDs(self):
+        headerProjA = copy.deepcopy(self.defaultHeaders)
+        headerProjB = copy.deepcopy(self.defaultHeaders)
+        headerProjA['X-Project-ID'] = '123450'
+        headerProjB['X-Project-ID'] = '281928'
+
+        # A - stays just under, B hits limit.
+        time.sleep(1)
+
+        callA = lambda: requests.get(
+            self.socketurl + '/v1/queues', headers=headerProjA)
+        callB = lambda: requests.get(
+            self.socketurl + '/v1/queues', headers=headerProjB)
+
+        respsA = [
+            callA().status_code for _ in range(self.limits['defaultLimit'])]
+        respsB = [callB().status_code for _ in range(
+            self.limits['281928defaultLimit'] + 1)]
+
+        self.assertNotEqual(respsA[-1], 429)
+        self.assertEqual(respsB[-1], 429)
+
+        # A and B are good independently
+        time.sleep(2)
+        respsA = [
+            callA().status_code for _ in range(self.limits['defaultLimit'])]
+
+        respsB = [callB().status_code for _ in range(
+            self.limits['281928defaultLimit'])]
+
+        self.assertNotEqual(respsA[-1], 429)
+        self.assertNotEqual(respsB[-1], 429)
+
+        # A and B hit limits independently
+        time.sleep(2)
+        respsA = [callA().status_code for _ in range(
+            self.limits['defaultLimit'] + 1)]
+
+        respsB = [callB().status_code for _ in range(
+            self.limits['281928defaultLimit'] + 1)]
+
+        self.assertEqual(respsA[-1], 429)
+        self.assertEqual(respsB[-1], 429)
+
+    def test_marconiErrors(self):
+        time.sleep(1)
+        urlQueue = self.socketurl + '/v1/queues/beeblebrox'
+
+        # delete queue, just in case
+        reqCheckQueue = requests.delete(urlQueue, headers=self.defaultHeaders)
+
+        # check 404 on dummy queue
+        reqCheckQueue = requests.get(urlQueue, headers=self.defaultHeaders)
+        self.assertEqual(reqCheckQueue.status_code, 404)
+
+        # create queue and check 400 on sending a large message
+        queueData = {'metadata': '42'}
+        reqAddQueue = requests.put(urlQueue,
+                                   data=json.dumps(queueData),
+                                   headers=self.defaultHeaders)
+        self.assertEqual(reqAddQueue.status_code, 201)
+
+        messageSize = 1538800
+        largeMsg = [{'ttl': 120, 'body': 'o' * messageSize}]
+        reqPostMsg = requests.post('%s/messages' % (urlQueue),
+                                   data=json.dumps(largeMsg),
+                                   headers=self.defaultHeaders)
+        self.assertEqual(reqPostMsg.status_code, 400)

--- a/tests/test_governor.py
+++ b/tests/test_governor.py
@@ -26,6 +26,7 @@ from wsgiref import simple_server
 
 import ddt
 import fakeredis
+from eom.utils import redis_pool
 import requests
 
 from eom import governor
@@ -89,6 +90,9 @@ def make_rate(limit, methods=None,
 def fakeredis_connection():
     return fakeredis.FakeRedis()
 
+def realredis_connection():
+    return redis_pool.get_client()
+
 
 class DTuple(tuple):
     pass
@@ -119,7 +123,8 @@ class TestGovernor(tests.util.TestCase):
 
     def setUp(self):
         super(TestGovernor, self).setUp()
-        redis_client = fakeredis_connection()
+        # redis_client = fakeredis_connection()
+        redis_client = realredis_connection()
         self.governor = governor.wrap(tests.util.app, redis_client)
 
         config = governor.CONF['eom:governor']
@@ -198,16 +203,19 @@ class TestGovernor(tests.util.TestCase):
 
     def test_limiter_raises_if_over_limit(self):
         call = lambda: self.limiter(1, self.test_rate)
-        [call() for _ in range(self.limit + 1)]
+        [call() for _ in range(self.limit)]
         self.assertRaises(governor.HardLimitError, call)
 
     def test_limit_reached_no_429(self):
+        time.sleep(1)
         self._test_limit(self.default_rate.limit, 204)
 
     def test_limit_surpassed_leads_to_429(self):
-        self._test_limit(self.default_rate.limit + 3, 429)
+        time.sleep(1)
+        self._test_limit(self.default_rate.limit + 1, 429)
 
     def test_draining_evades_429(self):
+        time.sleep(1)
         self._test_draining(self.default_rate.limit + 3, 204)
 
     #----------------------------------------------------------------------
@@ -220,7 +228,7 @@ class TestGovernor(tests.util.TestCase):
         host, port = '127.0.0.1', 8783
         with make_silent_server(self.governor, host, port):
             url = 'http://%s:%s' % (host, port) + self.test_url
-            call = lambda: request(url, headers={'X-Project-ID': 1234})
+            call = lambda: request(url, headers={'X-Project-ID': 123456})
             resps = [call().status_code for _ in range(limit)]
             self.assertEqual(resps[-1], expected_status)
 
@@ -232,6 +240,6 @@ class TestGovernor(tests.util.TestCase):
             url = 'http://%s:%s' % (host, port) + self.test_url
             call = lambda: request(url, headers={'X-Project-ID': 1234})
             [call().status_code for _ in range(limit // 2)]
-            time.sleep(0.5)
+            time.sleep(0.8)
             resp = [call().status_code for _ in range(limit // 2)][-1]
             self.assertEqual(resp, expected_status)

--- a/tests/test_governor.py
+++ b/tests/test_governor.py
@@ -123,8 +123,8 @@ class TestGovernor(tests.util.TestCase):
 
     def setUp(self):
         super(TestGovernor, self).setUp()
-        # redis_client = fakeredis_connection()
-        redis_client = realredis_connection()
+        redis_client = fakeredis_connection()
+        # redis_client = realredis_connection()
         self.governor = governor.wrap(tests.util.app, redis_client)
 
         config = governor.CONF['eom:governor']
@@ -228,7 +228,7 @@ class TestGovernor(tests.util.TestCase):
         host, port = '127.0.0.1', 8783
         with make_silent_server(self.governor, host, port):
             url = 'http://%s:%s' % (host, port) + self.test_url
-            call = lambda: request(url, headers={'X-Project-ID': 123456})
+            call = lambda: request(url, headers={'X-Project-ID': 1234})
             resps = [call().status_code for _ in range(limit)]
             self.assertEqual(resps[-1], expected_status)
 

--- a/tests/test_governor.py
+++ b/tests/test_governor.py
@@ -123,8 +123,8 @@ class TestGovernor(tests.util.TestCase):
 
     def setUp(self):
         super(TestGovernor, self).setUp()
-        redis_client = fakeredis_connection()
-        # redis_client = realredis_connection()
+        # redis_client = fakeredis_connection()
+        redis_client = realredis_connection()
         self.governor = governor.wrap(tests.util.app, redis_client)
 
         config = governor.CONF['eom:governor']


### PR DESCRIPTION
governor.py: Modified the rate limiting algorithm so that it guarantees request-limiting to <number> requests per second (if required, we can change this to different units like requests per hour, etc.) and removed a need for the server to force a delay upon itself or the client.

test_governor.py: Added the ability to use a real redis instance from the pool for testing. The new rate limiter currently causes two unit tests to fail while using the fake redis instance, but upon using a real redis instance, all tests pass. (Functional test will be updated and uploaded soon).
