### PR TITLE
Bug Fix: EOM Auth service catalog encoding/decoding

### DIFF
--- a/eom/auth.py
+++ b/eom/auth.py
@@ -385,8 +385,12 @@ def _validate_client(redis_client, url, tenant, token, env, blacklist_ttl):
             service_catalog_data = json.dumps(
                 access_info.service_catalog.catalog)
 
+            # convert service catalog to unicode to try to help
+            # prevent encode/decode errors under python2
+            u_service_catalog_data = u'{0}'.format(service_catalog_data)
+
             # Convert the JSON string data to strict UTF-8
-            utf8_data = service_catalog_data.encode(
+            utf8_data = u_service_catalog_data.encode(
                 encoding='utf-8', errors='strict')
 
             # Store it as Base64 for transport

--- a/eom/auth.py
+++ b/eom/auth.py
@@ -26,6 +26,7 @@ from oslo.config import cfg
 import redis
 from redis import connection
 import simplejson as json
+import six
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
@@ -387,7 +388,10 @@ def _validate_client(redis_client, url, tenant, token, env, blacklist_ttl):
 
             # convert service catalog to unicode to try to help
             # prevent encode/decode errors under python2
-            u_service_catalog_data = u'{0}'.format(service_catalog_data)
+            if six.PY2:  # pragma: no cover
+                u_service_catalog_data = service_catalog_data.decode('utf-8')
+            else:  # pragma: no cover
+                u_service_catalog_data = service_catalog_data
 
             # Convert the JSON string data to strict UTF-8
             utf8_data = u_service_catalog_data.encode(

--- a/eom/auth.py
+++ b/eom/auth.py
@@ -462,6 +462,18 @@ def _validate_client(redis_client, url, tenant, token, env, blacklist_ttl,
             # Store it as Base64 for transport
             env['HTTP_X_SERVICE_CATALOG'] = base64.b64encode(utf8_data)
 
+            try:
+                decode_check = base64.b64decode(env['HTTP_X_SERVICE_CATALOG'])
+
+            except Exception:
+                LOG.debug(_('Failed to decode the data properly'))
+                return False
+
+            if decode_check != utf8_data:
+                LOG.debug(_('Decode Check: decoded data does not match '
+                            'encoded data'))
+                return False
+
         # Project Scoped V3 or Tenant Scoped v2
         # This can be assumed since we validated using X_PROJECT_ID
         # and therefore have at least a v2 Tenant Scoped Token

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -597,6 +597,51 @@ class TestAuth(util.TestCase):
                                            self.default_max_cache_life)
             self.assertFalse(result)
 
+    def test_validate_client_b64decode_error(self):
+        url = 'myurl'
+        tenant_id = '172839405'
+        token = 'AaBbCcDdEeFf'
+
+        redis_client = fakeredis_connection()
+        bttl = 5
+
+        # The data that will get cached
+        access_info = fake_catalog(tenant_id, token)
+
+        # Encode a version of the data for verification tests later
+        data = access_info.service_catalog.catalog
+        json_data = json.dumps(data)
+        u_json_data = json_data
+        if six.PY2:
+            if isinstance(u_json_data, bytes):
+                u_json_data = json_data.decode('utf-8')
+        access_data_utf8 = u_json_data.encode(encoding='utf-8',
+                                              errors='strict')
+        access_data_b64 = base64.b64encode(access_data_utf8)
+
+        # We have data
+        with mock.patch(
+                'eom.auth._get_access_info') as MockGetAccessInfo:
+            with mock.patch(
+                    'eom.auth._is_token_blacklisted') as MockBlacklist:
+                with mock.patch(
+                        'base64.b64decode') as MockB64Decode:
+
+                    MockB64Decode.side_effect = Exception(
+                        'mock b64decode error')
+
+                    env_result = {}
+                    MockBlacklist.return_value = False
+                    MockGetAccessInfo.return_value = access_info
+                    result = auth._validate_client(redis_client,
+                                                   url,
+                                                   tenant_id,
+                                                   token,
+                                                   env_result,
+                                                   bttl,
+                                                   self.default_max_cache_life)
+                    self.assertFalse(result)
+
     def test_validate_client_valid_data(self):
         url = 'myurl'
         tenant_id = '172839405'

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -563,8 +563,10 @@ class TestAuth(util.TestCase):
 
         # Encode a version of the data for verification tests later
         data = access_info.service_catalog.catalog
-        access_data_utf8 = json.dumps(data).encode(encoding='utf-8',
-                                                   errors='strict')
+        json_data = json.dumps(data)
+        u_json_data = u'{0}'.format(json_data)
+        access_data_utf8 = u_json_data.encode(encoding='utf-8',
+                                              errors='strict')
         access_data_b64 = base64.b64encode(access_data_utf8)
 
         # We have data

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -25,6 +25,7 @@ from keystoneclient import exceptions
 import mock
 import msgpack.exceptions
 import simplejson as json
+import six
 
 from eom import auth
 import tests
@@ -564,7 +565,10 @@ class TestAuth(util.TestCase):
         # Encode a version of the data for verification tests later
         data = access_info.service_catalog.catalog
         json_data = json.dumps(data)
-        u_json_data = u'{0}'.format(json_data)
+        u_json_data = json_data
+        if six.PY2:
+            if isinstance(u_json_data, bytes):
+                u_json_data = json_data.decode('utf-8')
         access_data_utf8 = u_json_data.encode(encoding='utf-8',
                                               errors='strict')
         access_data_b64 = base64.b64encode(access_data_utf8)


### PR DESCRIPTION
- It has been observed that the encode/decode can sometimes fail. This is probably related to https://wiki.python.org/moin/UnicodeDecodeError as we were allowing the encoded string to be a string, not forcing it to be a unicode string
  This change forces it to be a unicode string which should negate the mentioned bug.

Note: For EOM Auth this has usually be a decode side bug complaining about a bad starting value.