### PR TITLE
Enhancement: Metrics update

### DIFF
--- a/etc/eom.conf-sample
+++ b/etc/eom.conf-sample
@@ -29,3 +29,10 @@ restricted_routes = /v1/stats, /v1/health
 
 [eom:uwsgi:mapper]
 options_file = map.json-sample
+
+[eom:metrics]
+address = http://localhost/statsd
+path_regexes_keys = *
+path_regexes_values = ^/
+prefix = None
+app_name = example_app

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,10 @@ ddt
 testtools
 mock
 
+# HTTP interface testing
+stackinabox
+requests-mock
+
 # Test runner
 nose
 nose-exclude

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,135 @@
+import mock
+from stackinabox.stack import StackInABox
+import stackinabox.util_requests_mock
+
+from eom import metrics
+from tests import util
+from tests.util.httpstatsd import HttpStatsdService
+from tests.util.statsd_http_client import HttpStatsdClient
+
+
+class TestMetrics(util.TestCase):
+
+    def setUp(self):
+        super(TestMetrics, self).setUp()
+        self.service = HttpStatsdService()
+        StackInABox.register_service(self.service)
+        self.statsd_client = HttpStatsdClient('http://localhost/statsd/')
+
+    def tearDown(self):
+        super(TestMetrics, self).tearDown()
+        StackInABox.reset_services()
+
+    def test_basic(self):
+        with stackinabox.util_requests_mock.activate():
+            stackinabox.util_requests_mock.requests_mock_registration(
+                'localhost')
+            with mock.patch('statsd.StatsClient') as mok_statsd_client:
+                mok_statsd_client.return_value = self.statsd_client
+
+                self.metrics = metrics.wrap(util.app)
+
+    def test_delete(self):
+        with stackinabox.util_requests_mock.activate():
+            stackinabox.util_requests_mock.requests_mock_registration(
+                'localhost')
+            with mock.patch('statsd.StatsClient') as mok_statsd_client:
+                mok_statsd_client.return_value = self.statsd_client
+
+                self.metrics = metrics.wrap(util.app)
+
+                my_env = self.create_env('/', method='DELETE')
+
+                self.assertIn('REQUEST_METHOD', my_env)
+                self.assertIn('PATH_INFO', my_env)
+                self.metrics(my_env, self.start_response)
+
+    def test_get(self):
+        with stackinabox.util_requests_mock.activate():
+            stackinabox.util_requests_mock.requests_mock_registration(
+                'localhost')
+            with mock.patch('statsd.StatsClient') as mok_statsd_client:
+                mok_statsd_client.return_value = self.statsd_client
+
+                self.metrics = metrics.wrap(util.app)
+
+                my_env = self.create_env('/', method='GET')
+
+                self.assertIn('REQUEST_METHOD', my_env)
+                self.assertIn('PATH_INFO', my_env)
+                self.metrics(my_env, self.start_response)
+
+    def test_head(self):
+        with stackinabox.util_requests_mock.activate():
+            stackinabox.util_requests_mock.requests_mock_registration(
+                'localhost')
+            with mock.patch('statsd.StatsClient') as mok_statsd_client:
+                mok_statsd_client.return_value = self.statsd_client
+
+                self.metrics = metrics.wrap(util.app)
+
+                my_env = self.create_env('/', method='HEAD')
+
+                self.assertIn('REQUEST_METHOD', my_env)
+                self.assertIn('PATH_INFO', my_env)
+                self.metrics(my_env, self.start_response)
+
+    def test_patch(self):
+        with stackinabox.util_requests_mock.activate():
+            stackinabox.util_requests_mock.requests_mock_registration(
+                'localhost')
+            with mock.patch('statsd.StatsClient') as mok_statsd_client:
+                mok_statsd_client.return_value = self.statsd_client
+
+                self.metrics = metrics.wrap(util.app)
+
+                my_env = self.create_env('/', method='PATCH')
+
+                self.assertIn('REQUEST_METHOD', my_env)
+                self.assertIn('PATH_INFO', my_env)
+                self.metrics(my_env, self.start_response)
+
+    def test_post(self):
+        with stackinabox.util_requests_mock.activate():
+            stackinabox.util_requests_mock.requests_mock_registration(
+                'localhost')
+            with mock.patch('statsd.StatsClient') as mok_statsd_client:
+                mok_statsd_client.return_value = self.statsd_client
+
+                self.metrics = metrics.wrap(util.app)
+
+                my_env = self.create_env('/', method='POST')
+
+                self.assertIn('REQUEST_METHOD', my_env)
+                self.assertIn('PATH_INFO', my_env)
+                self.metrics(my_env, self.start_response)
+
+    def test_put(self):
+        with stackinabox.util_requests_mock.activate():
+            stackinabox.util_requests_mock.requests_mock_registration(
+                'localhost')
+            with mock.patch('statsd.StatsClient') as mok_statsd_client:
+                mok_statsd_client.return_value = self.statsd_client
+
+                self.metrics = metrics.wrap(util.app)
+
+                my_env = self.create_env('/', method='PUT')
+
+                self.assertIn('REQUEST_METHOD', my_env)
+                self.assertIn('PATH_INFO', my_env)
+                self.metrics(my_env, self.start_response)
+
+    def test_invalid_method(self):
+        with stackinabox.util_requests_mock.activate():
+            stackinabox.util_requests_mock.requests_mock_registration(
+                'localhost')
+            with mock.patch('statsd.StatsClient') as mok_statsd_client:
+                mok_statsd_client.return_value = self.statsd_client
+
+                self.metrics = metrics.wrap(util.app)
+
+                my_env = self.create_env('/', method='INVALID')
+
+                self.assertIn('REQUEST_METHOD', my_env)
+                self.assertIn('PATH_INFO', my_env)
+                self.metrics(my_env, self.start_response)

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -19,6 +19,7 @@ import os
 from oslo.config import cfg
 import testtools
 
+
 CONF = cfg.CONF
 
 
@@ -90,7 +91,7 @@ class TestCase(testtools.TestCase):
 
         module_dir = os.path.abspath(os.path.dirname(__file__))
         parent = os.path.dirname(module_dir)
-        return os.path.join(parent, 'etc', filename)
+        return os.path.join(parent, '../etc', filename)
 
     def create_env(self, path, roles=None, project_id=None, auth_token=None,
                    method='GET'):

--- a/tests/util/httpstatsd.py
+++ b/tests/util/httpstatsd.py
@@ -1,0 +1,23 @@
+"""
+HTTP statsd Service Mock
+"""
+import re
+
+from stackinabox.services.service import StackInABoxService
+
+
+class HttpStatsdService(StackInABoxService):
+
+    def __init__(self):
+        super(HttpStatsdService, self).__init__('statsd')
+        self.register(StackInABoxService.PUT,
+                      re.compile('^/$'),
+                      HttpStatsdService.handler)
+        self.register(StackInABoxService.POST,
+                      re.compile('^/$'),
+                      HttpStatsdService.handler)
+
+    def handler(self, request, uri, headers):
+        print('HttpStatsdService ({0}): Received {1}'
+              .format(id(self), request.body))
+        return (201, headers, '')

--- a/tests/util/statsd_http_client.py
+++ b/tests/util/statsd_http_client.py
@@ -1,0 +1,18 @@
+
+import requests
+import statsd.client
+
+
+class HttpStatsdClient(statsd.client.StatsClientBase):
+
+    def __init__(self, url, prefix=None):
+        self._url = url
+        self._prefix = prefix
+
+    def _send(self, data):
+        res = requests.post(self._url, data=data)
+        if res.status_code != 201:
+            print('Call Failed')
+
+    def pipeline(self):
+        return statsd.client.TCPPipeline(self)


### PR DESCRIPTION
- Change the EOM Configuration Group for metrics from eom:statsd to eom:metrics
- Update EOM Metrics to not be specific to Marconi by making the app-name configurable
- Add tests
  - Created a statsd client that pushes data to an HTTP Backupend
  - Created a StackInABox Service to receive the statsd data
  - Setup tests to use StackInABox via Requests-Mock

Closes racker/eom#38