### PR TITLE
Enhancement EOM logging

### DIFF
--- a/eom/auth.py
+++ b/eom/auth.py
@@ -17,7 +17,6 @@
 import base64
 import datetime
 import functools
-import logging
 
 from keystoneclient import access
 from keystoneclient import exceptions
@@ -28,7 +27,8 @@ import redis
 from redis import connection
 import simplejson as json
 
-LOG = logging.getLogger(__name__)
+from eom.utils import log as logging
+
 CONF = cfg.CONF
 
 MAX_CACHE_LIFE_DEFAULT = ((datetime.datetime.max -
@@ -62,6 +62,10 @@ REDIS_OPTIONS = [
 ]
 
 CONF.register_opts(REDIS_OPTIONS, group=REDIS_GROUP_NAME)
+
+logging.register(CONF, AUTH_GROUP_NAME)
+logging.setup(CONF, AUTH_GROUP_NAME) 
+LOG = logging.getLogger(__name__)
 
 
 class InvalidKeystoneClient(Exception):
@@ -512,6 +516,7 @@ def wrap(app, redis_client):
     auth_url = group['auth_url']
     blacklist_ttl = group['blacklist_ttl']
     max_cache_life = group['max_cache_life']
+    
 
     LOG.debug('Auth URL: {0:}'.format(auth_url))
 

--- a/eom/bastion.py
+++ b/eom/bastion.py
@@ -49,10 +49,11 @@ Routes may also be separated by newlines, e.g.:
 
 """
 
-import logging
-
 from oslo.config import cfg
 
+from eom.utils import log as logging
+
+CONF = cfg.CONF
 
 OPT_GROUP_NAME = 'eom:bastion'
 OPTIONS = [
@@ -61,6 +62,10 @@ OPTIONS = [
                 default=[])
 ]
 
+CONF.register_opts(OPTIONS, group=OPT_GROUP_NAME)
+
+logging.register(CONF, OPT_GROUP_NAME)
+logging.setup(CONF, OPT_GROUP_NAME)
 LOG = logging.getLogger(__name__)
 
 
@@ -80,10 +85,7 @@ def wrap(app_backdoor, app_gated):
     :returns: a new WSGI app that wraps the original with bastion powers
     :rtype: wsgi_app
     """
-    conf = cfg.CONF
-
-    conf.register_opts(OPTIONS, group=OPT_GROUP_NAME)
-    restricted_routes = conf[OPT_GROUP_NAME].restricted_routes
+    restricted_routes = CONF[OPT_GROUP_NAME].restricted_routes
 
     # WSGI callable
     def middleware(env, start_response):

--- a/eom/governor.py
+++ b/eom/governor.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 from __future__ import division
-import logging
 import re
 import time
 
@@ -23,6 +22,8 @@ from oslo.config import cfg
 import redis
 import simplejson as json
 import six
+
+from eom.utils import log as logging
 
 
 CONF = cfg.CONF
@@ -45,6 +46,8 @@ OPTIONS = [
 CONF.register_opts(OPTIONS, group=REDIS_GROUP_NAME)
 
 
+logging.register(CONF, GOV_GROUP_NAME)
+logging.setup(CONF, GOV_GROUP_NAME)
 LOG = logging.getLogger(__name__)
 
 

--- a/eom/metrics.py
+++ b/eom/metrics.py
@@ -5,6 +5,10 @@ import time
 from oslo.config import cfg
 import statsd
 
+from eom.utils import log as logging
+
+CONF = cfg.CONF
+
 OPT_GROUP_NAME = 'eom:metrics'
 OPTIONS = [
     cfg.StrOpt('address',
@@ -35,16 +39,20 @@ OPTIONS = [
                required=True)
 ]
 
+CONF.register_opts(OPTIONS, group=OPT_GROUP_NAME)
+
+logging.register(CONF, OPT_GROUP_NAME)
+logging.setup(CONF, OPT_GROUP_NAME)
+LOG = logging.getLogger(__name__)
+
 
 def wrap(app):
-    conf = cfg.CONF
-    conf.register_opts(OPTIONS, group=OPT_GROUP_NAME)
-    addr = conf[OPT_GROUP_NAME].address
-    port = conf[OPT_GROUP_NAME].port
-    keys = conf[OPT_GROUP_NAME].path_regexes_keys
-    values = conf[OPT_GROUP_NAME].path_regexes_values
-    prefix = conf[OPT_GROUP_NAME].prefix
-    app_name = conf[OPT_GROUP_NAME].app_name
+    addr = CONF[OPT_GROUP_NAME].address
+    port = CONF[OPT_GROUP_NAME].port
+    keys = CONF[OPT_GROUP_NAME].path_regexes_keys
+    values = CONF[OPT_GROUP_NAME].path_regexes_values
+    prefix = CONF[OPT_GROUP_NAME].prefix
+    app_name = CONF[OPT_GROUP_NAME].app_name
 
     regex_strings = zip(keys, values)
     regex = []

--- a/eom/rbac.py
+++ b/eom/rbac.py
@@ -20,7 +20,8 @@ import re
 from oslo.config import cfg
 import simplejson as json
 
-LOG = logging.getLogger(__name__)
+from eom.utils import log as logging
+
 CONF = cfg.CONF
 
 OPT_GROUP_NAME = 'eom:rbac'
@@ -29,6 +30,10 @@ OPTION_NAME = 'acls_file'
 CONF.register_opt(cfg.StrOpt(OPTION_NAME), group=OPT_GROUP_NAME)
 
 EMPTY_SET = set()
+
+logging.register(CONF, OPT_GROUP_NAME)
+logging.setup(CONF, OPT_GROUP_NAME)
+LOG = logging.getLogger(__name__)
 
 
 def _load_rules(path):

--- a/eom/utils/log.py
+++ b/eom/utils/log.py
@@ -1,0 +1,20 @@
+from logging import *
+import logging.config
+
+from oslo.config import cfg
+
+LOG_APP_OPTIONS = [
+    cfg.StrOpt('log_config_file', default=None),
+    cfg.BoolOpt('log_config_disable_existing', default=True)
+]
+
+def register(config, app_section):
+    config.register_opts(LOG_APP_OPTIONS, group=app_section)
+
+def setup(config, app_section):
+    log_config_file = config[app_section]['log_config_file']
+    disable_existing = config[app_section]['log_config_disable_existing']
+
+    if log_config_file is not None:
+        config.fileConfig(log_config_file,
+                          disable_existing_loggers=disable_existing)

--- a/etc/eom.conf-sample
+++ b/etc/eom.conf-sample
@@ -1,3 +1,14 @@
+[DEFAULT]
+# Show more verbose log output (sets INFO log level output)
+;verbose = False
+
+# Show debugging output in logs (sets DEBUG log level output)
+;debug = False
+
+# Log to this file
+log_file = /var/log/eom/eom.log
+log_config_append = /etc/eom/logging.conf
+
 [eom:auth]
 auth_url = 'keystone.example.com/v2'
 blacklist_ttl = 3600000

--- a/etc/eom.conf-sample
+++ b/etc/eom.conf-sample
@@ -1,18 +1,9 @@
-[DEFAULT]
-# Show more verbose log output (sets INFO log level output)
-;verbose = False
-
-# Show debugging output in logs (sets DEBUG log level output)
-;debug = False
-
-# Log to this file
-log_file = /var/log/eom/eom.log
-log_config_append = /etc/eom/logging.conf
-
 [eom:auth]
 auth_url = 'keystone.example.com/v2'
 blacklist_ttl = 3600000
 max_cache_life = 600
+log_config_file = /etc/eom/logging.conf
+log_config_disable_existing = False
 
 [eom:auth_redis]
 host = 127.0.0.1
@@ -26,11 +17,15 @@ ssl_enable = False
 
 [eom:rbac]
 acls_file = rbac.json-sample
+log_config_file = /etc/eom/logging.conf
+log_config_disable_existing = False
 
 [eom:governor]
 rates_file = governor.json-sample
 project_rates_file = governor-project.json-sample
 throttle_milliseconds = 100
+log_config_file = /etc/eom/logging.conf
+log_config_disable_existing = False
 
 [eom:redis]
 host = 127.0.0.1
@@ -38,6 +33,8 @@ port = 6379
 
 [eom:bastion]
 restricted_routes = /v1/stats, /v1/health
+log_config_file = /etc/eom/logging.conf
+log_config_disable_existing = False
 
 [eom:uwsgi:mapper]
 options_file = map.json-sample
@@ -49,3 +46,5 @@ path_regexes_keys = *
 path_regexes_values = ^/
 prefix = None
 app_name = example_app
+log_config_file = /etc/eom/logging.conf
+log_config_disable_existing = False

--- a/etc/logging.conf-sample
+++ b/etc/logging.conf-sample
@@ -1,49 +1,40 @@
-[loggers]
-keys=root,server,combined
+[logging]
+    log_directory = /etc/eom/log
 
-[formatters]
-keys=normal,normal_with_name,debug
+[loggers]
+    [[root]]
+        level = DEBUG
+        handlers = rotatelogfile,
+    [[eom]]
+        level = DEBUG
+        handlers = rotatelogfile,
+     [[py.warnings]]
+        handlers = rotatelogfile,
 
 [handlers]
-keys=production,file,devel
+    [[console]]
+        level = DEBUG
+        class = logging.StreamHandler
+        formatter = standard
+    [[logfile]]
+        level = DEBUG
+        class = logging.FileHandler
+        formatter = standard
+        filename = /var/log/eom/eom.log
+    [[syslog]]
+        level = DEBUG
+        class = logging.handlers.SysLogHandler
+        formatter = standard
+        address = /dev/log
+    [[rotatelogfile]]
+        level = DEBUG
+        class = logging.handlers.RotatingFileHandler
+        formatter = standard
+        maxBytes = 400000000
+        backupCount = 2
+        filename = /var/log/eom/eom.log
 
-[logger_root]
-level=NOTSET
-handlers=file
+[formatters]
+    [[standard]]
+        format = '%(asctime)s %(levelname)-5.5s [%(name)s/%(lineno)d][%(threadName)s] : %(message)s'
 
-[logger_server]
-level=DEBUG
-handlers=file
-qualname=eom
-
-[logger_combined]
-level=DEBUG
-handlers=file
-qualname=eom-combined
-
-[handler_production]
-class=handlers.SysLogHandler
-level=ERROR
-formatter=normal_with_name
-args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_USER)
-
-[handler_file]
-class=FileHandler
-level=INFO
-formatter=debug
-args=('/var/log/eom/eom.log', 'a+')
-
-[handler_devel]
-class=StreamHandler
-level=NOTSET
-formatter=debug
-args=(sys.stdout,)
-
-[formatter_normal]
-format=%(asctime)s %(levelname)s %(message)s
-
-[formatter_normal_with_name]
-format=(%(name)s): %(asctime)s %(levelname)s %(message)s
-
-[formatter_debug]
-format=(%(name)s): %(asctime)s %(levelname)s %(module)s %(funcName)s %(message)s

--- a/etc/logging.conf-sample
+++ b/etc/logging.conf-sample
@@ -1,0 +1,49 @@
+[loggers]
+keys=root,server,combined
+
+[formatters]
+keys=normal,normal_with_name,debug
+
+[handlers]
+keys=production,file,devel
+
+[logger_root]
+level=NOTSET
+handlers=file
+
+[logger_server]
+level=DEBUG
+handlers=file
+qualname=eom
+
+[logger_combined]
+level=DEBUG
+handlers=file
+qualname=eom-combined
+
+[handler_production]
+class=handlers.SysLogHandler
+level=ERROR
+formatter=normal_with_name
+args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_USER)
+
+[handler_file]
+class=FileHandler
+level=INFO
+formatter=debug
+args=('/var/log/eom/eom.log', 'a+')
+
+[handler_devel]
+class=StreamHandler
+level=NOTSET
+formatter=debug
+args=(sys.stdout,)
+
+[formatter_normal]
+format=%(asctime)s %(levelname)s %(message)s
+
+[formatter_normal_with_name]
+format=(%(name)s): %(asctime)s %(levelname)s %(message)s
+
+[formatter_debug]
+format=(%(name)s): %(asctime)s %(levelname)s %(module)s %(funcName)s %(message)s


### PR DESCRIPTION
We noticed with Deuterium that EOM's log messages were not making it to the logs. This provides a simple, reliable method for that to happen.
- standard configparser log file format utilized
- all modules do the same thing
- all modules can be configured for the same logging configuration or each configured with their own

Testing is certainly required.