### PR TITLE
Enhancement no more global conf

### DIFF
--- a/eom/auth.py
+++ b/eom/auth.py
@@ -95,9 +95,12 @@ def configure(config):
     LOG = logging.getLogger(__name__)
 
 
-def get_conf():
+def get_conf(redis_config=False):
     global _CONF
-    return _CONF[AUTH_GROUP_NAME]
+    if redis_config:
+        return _CONF[REDIS_GROUP_NAME]
+    else:
+        return _CONF[AUTH_GROUP_NAME]
 
 
 def get_auth_redis_client():

--- a/eom/auth.py
+++ b/eom/auth.py
@@ -30,7 +30,7 @@ import six
 
 from eom.utils import log as logging
 
-CONF = cfg.CONF
+_CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
 MAX_CACHE_LIFE_DEFAULT = ((datetime.datetime.max -
@@ -84,16 +84,21 @@ class UnknownAuthenticationDataVersion(Exception):
 
 
 def configure(config):
-    global CONF
+    global _CONF
     global LOG
 
-    CONF = config
-    CONF.register_opts(AUTH_OPTIONS, group=AUTH_GROUP_NAME)
-    CONF.register_opts(REDIS_OPTIONS, group=REDIS_GROUP_NAME)
+    _CONF = config
+    _CONF.register_opts(AUTH_OPTIONS, group=AUTH_GROUP_NAME)
+    _CONF.register_opts(REDIS_OPTIONS, group=REDIS_GROUP_NAME)
 
-    logging.register(CONF, AUTH_GROUP_NAME)
-    logging.setup(CONF, AUTH_GROUP_NAME)
+    logging.register(_CONF, AUTH_GROUP_NAME)
+    logging.setup(_CONF, AUTH_GROUP_NAME)
     LOG = logging.getLogger(__name__)
+
+
+def get_conf():
+    global _CONF
+    return _CONF[AUTH_GROUP_NAME]
 
 
 def get_auth_redis_client():
@@ -101,7 +106,7 @@ def get_auth_redis_client():
 
     uses the eom:auth_redis settings
     """
-    group = CONF[REDIS_GROUP_NAME]
+    group = _CONF[REDIS_GROUP_NAME]
 
     if group['ssl_enable']:
         pool = redis.ConnectionPool(host=group['host'],
@@ -540,6 +545,7 @@ def wrap(app, redis_client):
     """Wrap a WSGI app with Authentication middleware.
 
     Takes configuration from oslo.config.cfg.CONF.
+    Requires auth.configure() be called first
 
     :param app: WSGI app to wrap
     :param redis_client: redis.Redis object connected to the redis cache
@@ -547,7 +553,7 @@ def wrap(app, redis_client):
     :returns: a new  WSGI app that wraps the original
     """
 
-    group = CONF[AUTH_GROUP_NAME]
+    group = _CONF[AUTH_GROUP_NAME]
     auth_url = group['auth_url']
     blacklist_ttl = group['blacklist_ttl']
     max_cache_life = group['max_cache_life']

--- a/eom/bastion.py
+++ b/eom/bastion.py
@@ -53,7 +53,7 @@ from oslo_config import cfg
 
 from eom.utils import log as logging
 
-CONF = cfg.CONF
+_CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
 OPT_GROUP_NAME = 'eom:bastion'
@@ -65,15 +65,20 @@ OPTIONS = [
 
 
 def configure(config):
-    global CONF
+    global _CONF
     global LOG
 
-    CONF = config
-    CONF.register_opts(OPTIONS, group=OPT_GROUP_NAME)
+    _CONF = config
+    _CONF.register_opts(OPTIONS, group=OPT_GROUP_NAME)
 
-    logging.register(CONF, OPT_GROUP_NAME)
-    logging.setup(CONF, OPT_GROUP_NAME)
+    logging.register(_CONF, OPT_GROUP_NAME)
+    logging.setup(_CONF, OPT_GROUP_NAME)
     LOG = logging.getLogger(__name__)
+
+
+def get_conf():
+    global _CONF
+    return _CONF[OPT_GROUP_NAME]
 
 
 def _http_gate_failure(start_response):
@@ -92,7 +97,7 @@ def wrap(app_backdoor, app_gated):
     :returns: a new WSGI app that wraps the original with bastion powers
     :rtype: wsgi_app
     """
-    unrestricted_routes = CONF[OPT_GROUP_NAME].unrestricted_routes
+    unrestricted_routes = _CONF[OPT_GROUP_NAME].unrestricted_routes
 
     # WSGI callable
     def middleware(env, start_response):

--- a/eom/governor.py
+++ b/eom/governor.py
@@ -26,7 +26,7 @@ import six
 from eom.utils import log as logging
 
 
-CONF = cfg.CONF
+_CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
 GOV_GROUP_NAME = 'eom:governor'
@@ -53,16 +53,21 @@ REDIS_OPTIONS = [
 
 
 def configure(config):
-    global CONF
+    global _CONF
     global LOG
 
-    CONF = config
-    CONF.register_opts(GOV_OPTIONS, group=GOV_GROUP_NAME)
-    CONF.register_opts(REDIS_OPTIONS, group=REDIS_GROUP_NAME)
+    _CONF = config
+    _CONF.register_opts(GOV_OPTIONS, group=GOV_GROUP_NAME)
+    _CONF.register_opts(REDIS_OPTIONS, group=REDIS_GROUP_NAME)
 
-    logging.register(CONF, GOV_GROUP_NAME)
-    logging.setup(CONF, GOV_GROUP_NAME)
+    logging.register(_CONF, GOV_GROUP_NAME)
+    logging.setup(_CONF, GOV_GROUP_NAME)
     LOG = logging.getLogger(__name__)
+
+
+def get_conf():
+    global _CONF
+    return _CONF[GOV_GROUP_NAME]
 
 
 def applies_to(rate, method, route):
@@ -118,7 +123,7 @@ class HardLimitError(Exception):
 
 
 def _load_json_file(path):
-    full_path = CONF.find_file(path)
+    full_path = _CONF.find_file(path)
     if not full_path:
         raise cfg.ConfigFilesNotFoundError([path or '<Empty>'])
 
@@ -227,7 +232,7 @@ def wrap(app, redis_client):
     :param redis_client: pooled redis client
     :returns: a new WSGI app that wraps the original
     """
-    group = CONF[GOV_GROUP_NAME]
+    group = _CONF[GOV_GROUP_NAME]
 
     rates_path = group['rates_file']
     project_rates_path = group['project_rates_file']

--- a/eom/metrics.py
+++ b/eom/metrics.py
@@ -70,7 +70,7 @@ def configure(config):
 
 def get_conf():
     global _CONF
-    return _CONF[AUTH_GROUP_NAME]
+    return _CONF[OPT_GROUP_NAME]
 
 
 def wrap(app):

--- a/eom/metrics.py
+++ b/eom/metrics.py
@@ -7,7 +7,7 @@ import statsd
 
 from eom.utils import log as logging
 
-CONF = cfg.CONF
+_CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
 OPT_GROUP_NAME = 'eom:metrics'
@@ -42,24 +42,29 @@ OPTIONS = [
 
 
 def configure(config):
-    global CONF
+    global _CONF
     global LOG
 
-    CONF = config
-    CONF.register_opts(OPTIONS, group=OPT_GROUP_NAME)
+    _CONF = config
+    _CONF.register_opts(OPTIONS, group=OPT_GROUP_NAME)
 
-    logging.register(CONF, OPT_GROUP_NAME)
-    logging.setup(CONF, OPT_GROUP_NAME)
+    logging.register(_CONF, OPT_GROUP_NAME)
+    logging.setup(_CONF, OPT_GROUP_NAME)
     LOG = logging.getLogger(__name__)
 
 
+def get_conf():
+    global _CONF
+    return _CONF[AUTH_GROUP_NAME]
+
+
 def wrap(app):
-    addr = CONF[OPT_GROUP_NAME].address
-    port = CONF[OPT_GROUP_NAME].port
-    keys = CONF[OPT_GROUP_NAME].path_regexes_keys
-    values = CONF[OPT_GROUP_NAME].path_regexes_values
-    prefix = CONF[OPT_GROUP_NAME].prefix
-    app_name = CONF[OPT_GROUP_NAME].app_name
+    addr = _CONF[OPT_GROUP_NAME].address
+    port = _CONF[OPT_GROUP_NAME].port
+    keys = _CONF[OPT_GROUP_NAME].path_regexes_keys
+    values = _CONF[OPT_GROUP_NAME].path_regexes_values
+    prefix = _CONF[OPT_GROUP_NAME].prefix
+    app_name = _CONF[OPT_GROUP_NAME].app_name
 
     regex_strings = zip(keys, values)
     regex = []

--- a/eom/rbac.py
+++ b/eom/rbac.py
@@ -43,7 +43,7 @@ def configure(config):
 
 def get_conf():
     global _CONF
-    return _CONF[AUTH_GROUP_NAME]
+    return _CONF[OPT_GROUP_NAME]
 
 
 def _load_rules(path):

--- a/eom/rbac.py
+++ b/eom/rbac.py
@@ -21,7 +21,7 @@ import simplejson as json
 
 from eom.utils import log as logging
 
-CONF = cfg.CONF
+_CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
 OPT_GROUP_NAME = 'eom:rbac'
@@ -31,19 +31,24 @@ EMPTY_SET = set()
 
 
 def configure(config):
-    global CONF
+    global _CONF
     global LOG
 
-    CONF = config
-    CONF.register_opt(cfg.StrOpt(OPTION_NAME), group=OPT_GROUP_NAME)
+    _CONF = config
+    _CONF.register_opt(cfg.StrOpt(OPTION_NAME), group=OPT_GROUP_NAME)
 
-    logging.register(CONF, OPT_GROUP_NAME)
-    logging.setup(CONF, OPT_GROUP_NAME)
+    logging.register(_CONF, OPT_GROUP_NAME)
+    logging.setup(_CONF, OPT_GROUP_NAME)
     LOG = logging.getLogger(__name__)
 
 
+def get_conf():
+    global _CONF
+    return _CONF[AUTH_GROUP_NAME]
+
+
 def _load_rules(path):
-    full_path = CONF.find_file(path)
+    full_path = _CONF.find_file(path)
     if not full_path:
         raise cfg.ConfigFilesNotFoundError([path])
 
@@ -101,7 +106,7 @@ def wrap(app):
     :param app: WSGI app to wrap
     :returns: a new WSGI app that wraps the original
     """
-    group = CONF[OPT_GROUP_NAME]
+    group = _CONF[OPT_GROUP_NAME]
     rules_path = group[OPTION_NAME]
     rules = _load_rules(rules_path)
     acl_map = _create_acl_map(rules)

--- a/eom/utils/log.py
+++ b/eom/utils/log.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import logging.config
-from logging import getLogger
+from logging import getLogger as logging_getLogger
 
 from oslo_config import cfg
 
@@ -35,3 +35,7 @@ def setup(config, app_section):
     if log_config_file is not None:
         logging.config.fileConfig(log_config_file,
                                   disable_existing_loggers=disable_existing)
+
+
+def getLogger(*args, **kwargs):
+    return logging_getLogger(*args, **kwargs)

--- a/eom/utils/redis_pool.py
+++ b/eom/utils/redis_pool.py
@@ -1,7 +1,7 @@
 from oslo_config import cfg
 import redis
 
-CONF = cfg.CONF
+_CONF = cfg.CONF
 
 REDIS_GROUP_NAME = 'eom:redis'
 OPTIONS = [
@@ -9,10 +9,10 @@ OPTIONS = [
     cfg.StrOpt('port'),
 ]
 
-CONF.register_opts(OPTIONS, group=REDIS_GROUP_NAME)
+_CONF.register_opts(OPTIONS, group=REDIS_GROUP_NAME)
 
 
 def get_client():
-    group = CONF[REDIS_GROUP_NAME]
+    group = _CONF[REDIS_GROUP_NAME]
     pool = redis.ConnectionPool(host=group['host'], port=group['port'], db=0)
     return redis.Redis(connection_pool=pool)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -132,6 +132,17 @@ class TestAuth(util.TestCase):
         # config = auth.CONF['eom:auth']
         # config['auth_url'] = self.runtime_url
 
+    def test_get_conf_auth(self):
+        config = auth.get_conf()
+        self.assertIsNotNone(config)
+
+    def test_get_conf_auth_redis(self):
+        auth_config = auth.get_conf()
+        redis_config = auth.get_conf(True)
+        self.assertIsNotNone(auth_config)
+        self.assertIsNotNone(redis_config)
+        self.assertNotEqual(auth_config, redis_config)
+
     def test_cache_key(self):
         value_input = ('1', '2', '3', '4')
         value_output = "(1,2,3,4)"

--- a/tests/test_bastion.py
+++ b/tests/test_bastion.py
@@ -44,6 +44,10 @@ class TestBastion(util.TestCase):
         self.bastion(env, self.start_response)
         self.assertEqual(self.status, lookup[code])
 
+    def test_get_conf(self):
+        config = bastion.get_conf()
+        self.assertIsNotNone(config)
+
     def test_restricted_route_hits_gate(self):
         env = self.create_env(self.normal_route)
         self._expect(env, 403)

--- a/tests/test_governor.py
+++ b/tests/test_governor.py
@@ -142,6 +142,10 @@ class TestGovernor(util.TestCase):
         redis_client = fakeredis_connection()
         redis_client.flushall()
 
+    def test_get_conf(self):
+        config = governor.get_conf()
+        self.assertIsNotNone(config)
+
     def test_missing_project_id(self):
         env = self.create_env('/v1')
         self.governor(env, self.start_response)

--- a/tests/test_governor.py
+++ b/tests/test_governor.py
@@ -126,7 +126,7 @@ class TestGovernor(util.TestCase):
         governor.configure(util.CONF)
         self.governor = governor.wrap(util.app, redis_client)
 
-        config = governor.CONF['eom:governor']
+        config = governor.get_conf()
         rates = governor._load_rates(config['rates_file'])
 
         self.test_rate = rates[0]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -38,6 +38,10 @@ class TestMetrics(util.TestCase):
         super(TestMetrics, self).tearDown()
         StackInABox.reset_services()
 
+    def test_get_conf(self):
+        config = metrics.get_conf()
+        self.assertIsNotNone(config)
+
     def test_basic(self):
         with stackinabox.util_requests_mock.activate():
             stackinabox.util_requests_mock.requests_mock_registration(

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -27,6 +27,10 @@ class TestRBAC(util.TestCase):
 
         self.rbac = eom.rbac.wrap(util.app)
 
+    def test_get_conf(self):
+        config = eom.rbac.get_conf()
+        self.assertIsNotNone(config)
+
     def test_noacl(self):
         env = self.create_env('/v1')
         self.rbac(env, self.start_response)

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,5 @@ commands = {posargs}
 
 [flake8]
 builtins = _
-exclude = .venv,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*.egg,.update-venv
+exclude = build,env*,.venv,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*.egg,.update-venv
 


### PR DESCRIPTION
- CONF is moved to module specific namespace
- get_conf() introduced for the rare occasions it's necessary to access the module's configuration from outside of it
- added unit tests for all get_conf()
- cleaned up util.log so that it passes PEP8 (dumb but required!)

Closes #31 