### PR TITLE
Allow a range of keystoneclient versions for dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ hiredis>=0.1.3
 msgpack-python>=0.4.6
 oslo.config==2.2.0
 pbr>=1.4.0
-python-keystoneclient==1.6.0
+python-keystoneclient>=1.6.0,<2
 redis>=2.9.1
 simplejson
 six


### PR DESCRIPTION
See #106. Tox tests return one error, one failure, and four slow. However, I get the same results against master, so I don't think it's a problem with the PR.