### PR TITLE
Fix oslo.config dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 d2to1>=0.2.10
 hiredis>=0.1.3
 msgpack-python>=0.4.6
-oslo.config==2.2.0
+oslo.config>=2.2.0,<3
 pbr>=1.4.0
 python-keystoneclient>=1.6.0,<2
 redis>=2.9.1


### PR DESCRIPTION
EOM currently depends on oslo.config==2.2.0, but keystoneclient depends
on oslo.config>=2.3.0.

To reproduce:

```
python setup.py bdist_wheel
virtualenv venv
. venv/bin/activate
pip install dist/$wheelfile
pip install pipdeptree
pipdeptree
```

This is basically the same thing as #107. I just neglected to check again the keystoneclient fix.